### PR TITLE
Fix bug when transitioning to same color/brightness

### DIFF
--- a/limitlessled/group/rgbw.py
+++ b/limitlessled/group/rgbw.py
@@ -157,11 +157,14 @@ class RgbwGroup(Group):
         if brightness is not None:
             b_steps = steps(self.brightness,
                             brightness, BRIGHTNESS_STEPS)
+            b_start = self.brightness
         # Calculate color steps.
         c_steps = 0
         if color is not None:
             c_steps = abs(util.rgb_to_hue(*self.color)
                           - util.rgb_to_hue(*color))
+            c_start = rgb_to_hsv(*self._color)
+            c_end = rgb_to_hsv(*color)
         # Compute ideal step amount (at least one).
         total = max(c_steps + b_steps, 1)
         # Calculate wait.
@@ -169,11 +172,6 @@ class RgbwGroup(Group):
         # Scale down steps if no wait time.
         if wait == 0:
             total = self._scaled_steps(duration, total, total)
-        # Calculate start and end.
-        if total != b_steps:
-            c_start = rgb_to_hsv(*self._color)
-            c_end = rgb_to_hsv(*color)
-        b_start = self.brightness
         # Perform transition.
         j = 0
         for i in range(total):


### PR DESCRIPTION
I ran into this [this issue #3541 with Home Assistant](https://github.com/home-assistant/home-assistant/issues/3541), and upgrading to the new version 1.0.1 of limitlessled just changed the traceback.

```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/threading.py", line 911, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.4/site-packages/limitlessled/pipeline.py", line 32, in run
    self._queue.get().run(self._event)
  File "/usr/local/lib/python3.4/site-packages/limitlessled/pipeline.py", line 109, in run
    self._execute_stage(i, stage, stop)
  File "/usr/local/lib/python3.4/site-packages/limitlessled/pipeline.py", line 163, in _execute_stage
    self._group.transition(*stage.args, **stage.kwargs)
  File "/usr/local/lib/python3.4/site-packages/limitlessled/group/rgbw.py", line 145, in transition
    self._transition(duration, color, brightness)
  File "/usr/local/lib/python3.4/site-packages/limitlessled/group/__init__.py", line 34, in wrapper
    function(self, *args, **kwargs)
  File "/usr/local/lib/python3.4/site-packages/limitlessled/group/rgbw.py", line 175, in _transition
    c_end = rgb_to_hsv(*color)
TypeError: rgb_to_hsv() argument after * must be a sequence, not NoneType
```

This was a minimal testcase I used to reproduce the HA bug.
```python
#!/usr/bin/env python

from limitlessled.bridge import Bridge
from limitlessled.group.rgbw import RGBW
from limitlessled import Color

b=Bridge('10.0.4.2')
g=b.add_group(1,'office',RGBW)

g.transition(brightness=.5, color=Color(255,255,255),duration=1)
g.transition(brightness=.49, color=Color(255,255,255),duration=.01)
```