### PR TITLE
Add support for 1CH MiLight dimmer

### DIFF
--- a/limitlessled/bridge.py
+++ b/limitlessled/bridge.py
@@ -11,6 +11,7 @@ from limitlessled.group.rgbw import RgbwGroup, RGBW, BRIDGE_LED
 from limitlessled.group.wrgb import WrgbGroup, WRGB
 from limitlessled.group.rgbww import RgbwwGroup, RGBWW
 from limitlessled.group.white import WhiteGroup, WHITE
+from limitlessled.group.dimmer import DimmerGroup, DIMMER
 
 
 BRIDGE_PORT = 5987
@@ -36,7 +37,7 @@ def group_factory(bridge, number, name, led_type):
     :param bridge: Member of this bridge.
     :param number: Group number (1-4).
     :param name: Name of group.
-    :param led_type: Either `RGBW`, `WRGB`, `RGBWW`, `WHITE` or `BRIDGE_LED`.
+    :param led_type: Either `RGBW`, `WRGB`, `RGBWW`, `WHITE`, `DIMMER` or `BRIDGE_LED`.
     :returns: New group.
     """
     if led_type in [RGBW, BRIDGE_LED]:
@@ -45,6 +46,8 @@ def group_factory(bridge, number, name, led_type):
         return RgbwwGroup(bridge, number, name)
     elif led_type == WHITE:
         return WhiteGroup(bridge, number, name)
+    elif led_type == DIMMER:
+        return DimmerGroup(bridge, number, name)
     elif led_type == WRGB:
         return WrgbGroup(bridge, number, name)
     else:
@@ -145,7 +148,7 @@ class Bridge(object):
 
         :param number: Group number (1-4).
         :param name: Group name.
-        :param led_type: Either `RGBW`, `WRGB`, `RGBWW`, `WHITE` or `BRIDGE_LED`.
+        :param led_type: Either `RGBW`, `WRGB`, `RGBWW`, `WHITE`, `DIMMER` or `BRIDGE_LED`.
         :returns: Added group.
         """
         group = group_factory(self, number, name, led_type)

--- a/limitlessled/group/commands/__init__.py
+++ b/limitlessled/group/commands/__init__.py
@@ -14,11 +14,13 @@ def command_set_factory(bridge, group_number, led_type):
         CommandSetWhiteLegacy, CommandSetRgbwLegacy)
     from limitlessled.group.commands.v6 import (
         CommandSetBridgeLightV6, CommandSetWhiteV6,
-        CommandSetRgbwV6, CommandSetRgbwwV6, CommandSetWrgbV6)
+        CommandSetDimmerV6, CommandSetRgbwV6,
+        CommandSetRgbwwV6, CommandSetWrgbV6)
 
     command_sets = [CommandSetWhiteLegacy, CommandSetRgbwLegacy,
                     CommandSetBridgeLightV6, CommandSetWhiteV6,
-                    CommandSetRgbwV6, CommandSetRgbwwV6, CommandSetWrgbV6]
+                    CommandSetDimmerV6, CommandSetRgbwV6,
+                    CommandSetRgbwwV6, CommandSetWrgbV6]
     try:
         cls = next(cs for cs in command_sets if
                    bridge.version in cs.SUPPORTED_VERSIONS and

--- a/limitlessled/group/commands/v6.py
+++ b/limitlessled/group/commands/v6.py
@@ -7,6 +7,7 @@ from limitlessled.group.rgbw import RGBW, BRIDGE_LED
 from limitlessled.group.rgbww import RGBWW
 from limitlessled.group.wrgb import WRGB
 from limitlessled.group.white import WHITE
+from limitlessled.group.dimmer import DIMMER
 from limitlessled.group.commands import CommandSet, Command
 
 
@@ -242,6 +243,47 @@ class CommandSetWhiteV6(CommandSetV6):
         """
         return self._build_command(0x01, self.convert_temperature(temperature))
 
+class CommandSetDimmerV6(CommandSetV6):
+    """ Command set for Dimmer LED dimmer (1CH MiLight dimmer) connected to wifi bridge v6. """
+
+    SUPPORTED_LED_TYPES = [DIMMER]
+    REMOTE_STYLE = 0x03
+
+    def __init__(self, group_number):
+        """
+        Initializes the command set.
+        :param group_number: The group number.
+        """
+        super().__init__(group_number, self.REMOTE_STYLE)
+
+    def on(self):
+        """
+        Build command for turning the dimmer on.
+        :return: The command.
+        """
+        return self._build_command(0x04, 0x03)
+
+    def off(self):
+        """
+        Build command for turning the dimmer off.
+        :return: The command.
+        """
+        return self._build_command(0x04, 0x04)
+
+    def night_light(self):
+        """
+        Build command for turning the dimmer into night light mode.
+        :return: The command.
+        """
+        return self._build_command(0x04, 0x02)
+
+    def brightness(self, brightness):
+        """
+        Build command for setting the brightness of the controller.
+        :param brightness: Value to set (0.0-1.0).
+        :return: The command.
+        """
+        return self._build_command(0x01, self.convert_brightness(brightness))
 
 class CommandSetRgbwV6(CommandSetV6):
     """ Command set for RGBW led light connected to wifi bridge v6. """

--- a/limitlessled/group/dimmer.py
+++ b/limitlessled/group/dimmer.py
@@ -23,7 +23,6 @@ class DimmerGroup(Group):
         :param name: Group name.
         """
         super().__init__(bridge, number, name, DIMMER)
-        # self._temperature = 0.5
 
     @property
     def brightness(self):
@@ -48,98 +47,48 @@ class DimmerGroup(Group):
                          self._dimmest, self._brightest,
                          self._to_brightness)
 
-    # @property
-    # def temperature(self):
-    #     """ Temperature property.
-    #
-    #     :returns: Temperature (0.0-1.0)
-    #     """
-    #     return self._temperature
-    #
-    # @temperature.setter
-    # def temperature(self, temperature):
-    #     """ Set the temperature.
-    #
-    #     :param temperature: Value to set (0.0-1.0).
-    #     """
-    #     try:
-    #         cmd = self.command_set.temperature(temperature)
-    #         self.send(cmd)
-    #         self._temperature = temperature
-    #     except AttributeError:
-    #         self._setter('_temperature', temperature,
-    #                      self._coolest, self._warmest,
-    #                      self._to_temperature)
-
     def transition(self, duration, brightness=None):
-    # def transition(self, duration, brightness=None, temperature=None):
         """ Transition wrapper.
 
         Short-circuit transition if necessary.
 
         :param duration: Duration of transition.
         :param brightness: Transition to this brightness.
-        :param temperature: Transition to this temperature.
         """
-        # Transition immediately if duration is zero.
         if duration == 0:
             if brightness is not None:
                 self.brightness = brightness
-            # if temperature is not None:
-            #     self.temperature = temperature
             return
         if brightness != self.brightness:
             self._transition(duration, brightness)
-        # if brightness != self.brightness or temperature != self.temperature:
-        #     self._transition(duration, brightness, temperature)
 
     @rate(reps=1)
     def _transition(self, duration, brightness):
-    # def _transition(self, duration, brightness, temperature):
         """ Complete a transition.
 
         :param duration: Duration of transition.
         :param brightness: Transition to this brightness.
-        :param temperature: Transition to this temperature.
         """
         # Set initial value.
         b_start = self.brightness
-        # t_start = self.temperature
         # Compute ideal step amount.
         b_steps = 0
         if brightness is not None:
             b_steps = steps(self.brightness, brightness,
                             self.command_set.brightness_steps)
-        # t_steps = 0
-        # if temperature is not None:
-        #     t_steps = steps(self.temperature, temperature,
-        #                     self.command_set.temperature_steps)
         # Compute ideal step amount (at least one).
-        total_steps = b_steps
-        total_commands = b_steps
-        # total_steps = max(b_steps, t_steps, 1)
-        # total_commands = b_steps + t_steps
         # Calculate wait.
-        wait = self._wait(duration, total_steps, total_commands)
+        wait = self._wait(duration, b_steps, b_steps)
         # Scale down steps if no wait time.
         if wait == 0:
-            b_steps = self._scale_steps(duration, total_commands,
+            b_steps = self._scale_steps(duration, b_steps,
                                                  b_steps)
-            # b_steps, t_steps = self._scale_steps(duration, total_commands,
-            #                                      b_steps, t_steps)
-            total_steps = b_steps
-            # total_steps = max(b_steps, t_steps, 1)
         # Perform transition.
-        for i in range(total_steps):
+        for i in range(b_steps):
             # Brightness.
-            if b_steps > 0 and i % (total_steps / b_steps) == 0:
-                self.brightness = util.transition(i, total_steps,
+            if b_steps > 0:
+                self.brightness = util.transition(i, b_steps,
                                                   b_start, brightness)
-            # Temperature.
-            # elif t_steps > 0:
-            #     self.temperature = util.transition(i, total_steps,
-            #                                        t_start, temperature)
-            # Wait.
             time.sleep(wait)
 
     def _setter(self, attr, value, bottom, top, to_step):
@@ -169,15 +118,6 @@ class DimmerGroup(Group):
         self._to_value(self._brightness, brightness,
                        self.command_set.brightness_steps,
                        self._dimmer, self._brighter)
-
-    # def _to_temperature(self, temperature):
-    #     """ Step to a given temperature.
-    #
-    #     :param temperature: Get to this temperature.
-    #     """
-    #     self._to_value(self._temperature, temperature,
-    #                    self.command_set.temperature_steps,
-    #                    self._cooler, self._warmer)
 
     @rate(reps=1)
     def _to_value(self, current, target, max_steps, step_down, step_up):
@@ -209,20 +149,6 @@ class DimmerGroup(Group):
                              self.command_set.brightness_steps)):
             self._dimmer()
 
-    # @rate(wait=0.025, reps=2)
-    # def _warmest(self):
-    #     """ Group temperature as warm as possible. """
-    #     for _ in range(steps(self.temperature, 1.0,
-    #                          self.command_set.temperature_steps)):
-    #         self._warmer()
-
-    # @rate(wait=0.025, reps=2)
-    # def _coolest(self):
-    #     """ Group temperature as cool as possible. """
-    #     for _ in range(steps(self.temperature, 0.0,
-    #                          self.command_set.temperature_steps)):
-    #         self._cooler()
-
     def _brighter(self):
         """ One step brighter. """
         self.send(self.command_set.brighter())
@@ -230,11 +156,3 @@ class DimmerGroup(Group):
     def _dimmer(self):
         """ One step dimmer. """
         self.send(self.command_set.dimmer())
-
-    # def _warmer(self):
-    #     """ One step warmer. """
-    #     self.send(self.command_set.warmer())
-
-    # def _cooler(self):
-    #     """ One step cooler. """
-    #     self.send(self.command_set.cooler())

--- a/limitlessled/group/dimmer.py
+++ b/limitlessled/group/dimmer.py
@@ -1,0 +1,240 @@
+""" Dimmer controller LimitlessLED group. """
+
+import time
+
+from limitlessled import util
+from limitlessled.group import Group, rate
+from limitlessled.util import steps
+
+DIMMER = 'dimmer'
+
+
+class DimmerGroup(Group):
+    """ Dimmer LimitlessLED group. """
+
+    def __init__(self, bridge, number, name):
+        """ Initialize dimmer group.
+
+        Brightness must be initialized
+        to some value.
+
+        :param bridge: Associated bridge.
+        :param number: Group number (1-4).
+        :param name: Group name.
+        """
+        super().__init__(bridge, number, name, DIMMER)
+        # self._temperature = 0.5
+
+    @property
+    def brightness(self):
+        """ Brightness property.
+
+        :returns: Brightness.
+        """
+        return self._brightness
+
+    @brightness.setter
+    def brightness(self, brightness):
+        """ Set the brightness.
+
+        :param brightness: Value to set (0.0-1.0).
+        """
+        try:
+            cmd = self.command_set.brightness(brightness)
+            self.send(cmd)
+            self._brightness = brightness
+        except AttributeError:
+            self._setter('_brightness', brightness,
+                         self._dimmest, self._brightest,
+                         self._to_brightness)
+
+    # @property
+    # def temperature(self):
+    #     """ Temperature property.
+    #
+    #     :returns: Temperature (0.0-1.0)
+    #     """
+    #     return self._temperature
+    #
+    # @temperature.setter
+    # def temperature(self, temperature):
+    #     """ Set the temperature.
+    #
+    #     :param temperature: Value to set (0.0-1.0).
+    #     """
+    #     try:
+    #         cmd = self.command_set.temperature(temperature)
+    #         self.send(cmd)
+    #         self._temperature = temperature
+    #     except AttributeError:
+    #         self._setter('_temperature', temperature,
+    #                      self._coolest, self._warmest,
+    #                      self._to_temperature)
+
+    def transition(self, duration, brightness=None):
+    # def transition(self, duration, brightness=None, temperature=None):
+        """ Transition wrapper.
+
+        Short-circuit transition if necessary.
+
+        :param duration: Duration of transition.
+        :param brightness: Transition to this brightness.
+        :param temperature: Transition to this temperature.
+        """
+        # Transition immediately if duration is zero.
+        if duration == 0:
+            if brightness is not None:
+                self.brightness = brightness
+            # if temperature is not None:
+            #     self.temperature = temperature
+            return
+        if brightness != self.brightness:
+            self._transition(duration, brightness)
+        # if brightness != self.brightness or temperature != self.temperature:
+        #     self._transition(duration, brightness, temperature)
+
+    @rate(reps=1)
+    def _transition(self, duration, brightness):
+    # def _transition(self, duration, brightness, temperature):
+        """ Complete a transition.
+
+        :param duration: Duration of transition.
+        :param brightness: Transition to this brightness.
+        :param temperature: Transition to this temperature.
+        """
+        # Set initial value.
+        b_start = self.brightness
+        # t_start = self.temperature
+        # Compute ideal step amount.
+        b_steps = 0
+        if brightness is not None:
+            b_steps = steps(self.brightness, brightness,
+                            self.command_set.brightness_steps)
+        # t_steps = 0
+        # if temperature is not None:
+        #     t_steps = steps(self.temperature, temperature,
+        #                     self.command_set.temperature_steps)
+        # Compute ideal step amount (at least one).
+        total_steps = b_steps
+        total_commands = b_steps
+        # total_steps = max(b_steps, t_steps, 1)
+        # total_commands = b_steps + t_steps
+        # Calculate wait.
+        wait = self._wait(duration, total_steps, total_commands)
+        # Scale down steps if no wait time.
+        if wait == 0:
+            b_steps = self._scale_steps(duration, total_commands,
+                                                 b_steps)
+            # b_steps, t_steps = self._scale_steps(duration, total_commands,
+            #                                      b_steps, t_steps)
+            total_steps = b_steps
+            # total_steps = max(b_steps, t_steps, 1)
+        # Perform transition.
+        for i in range(total_steps):
+            # Brightness.
+            if b_steps > 0 and i % (total_steps / b_steps) == 0:
+                self.brightness = util.transition(i, total_steps,
+                                                  b_start, brightness)
+            # Temperature.
+            # elif t_steps > 0:
+            #     self.temperature = util.transition(i, total_steps,
+            #                                        t_start, temperature)
+            # Wait.
+            time.sleep(wait)
+
+    def _setter(self, attr, value, bottom, top, to_step):
+        """ Set a value.
+
+        :param attr: Attribute to set.
+        :param value: Value to use.
+        :param bottom: Get to bottom value.
+        :param top: Get to top value.
+        :param to_step: Get to intermediary value.
+        """
+        if value < 0 or value > 1:
+            raise ValueError("out of range")
+        if value == 0.0:
+            bottom()
+        elif value == 1.0:
+            top()
+        else:
+            to_step(value)
+        setattr(self, attr, value)
+
+    def _to_brightness(self, brightness):
+        """ Step to a given brightness.
+
+        :param brightness: Get to this brightness.
+        """
+        self._to_value(self._brightness, brightness,
+                       self.command_set.brightness_steps,
+                       self._dimmer, self._brighter)
+
+    # def _to_temperature(self, temperature):
+    #     """ Step to a given temperature.
+    #
+    #     :param temperature: Get to this temperature.
+    #     """
+    #     self._to_value(self._temperature, temperature,
+    #                    self.command_set.temperature_steps,
+    #                    self._cooler, self._warmer)
+
+    @rate(reps=1)
+    def _to_value(self, current, target, max_steps, step_down, step_up):
+        """ Step to a value
+
+        :param current: Current value.
+        :param target: Target value.
+        :param max_steps: Maximum number of steps.
+        :param step_down: Down function.
+        :param step_up: Up function.
+        """
+        for _ in range(steps(current, target, max_steps)):
+            if (current - target) > 0:
+                step_down()
+            else:
+                step_up()
+
+    @rate(wait=0.025, reps=2)
+    def _brightest(self):
+        """ Group as bright as possible. """
+        for _ in range(steps(self.brightness, 1.0,
+                             self.command_set.brightness_steps)):
+            self._brighter()
+
+    @rate(wait=0.025, reps=2)
+    def _dimmest(self):
+        """ Group brightness as dim as possible. """
+        for _ in range(steps(self.brightness, 0.0,
+                             self.command_set.brightness_steps)):
+            self._dimmer()
+
+    # @rate(wait=0.025, reps=2)
+    # def _warmest(self):
+    #     """ Group temperature as warm as possible. """
+    #     for _ in range(steps(self.temperature, 1.0,
+    #                          self.command_set.temperature_steps)):
+    #         self._warmer()
+
+    # @rate(wait=0.025, reps=2)
+    # def _coolest(self):
+    #     """ Group temperature as cool as possible. """
+    #     for _ in range(steps(self.temperature, 0.0,
+    #                          self.command_set.temperature_steps)):
+    #         self._cooler()
+
+    def _brighter(self):
+        """ One step brighter. """
+        self.send(self.command_set.brighter())
+
+    def _dimmer(self):
+        """ One step dimmer. """
+        self.send(self.command_set.dimmer())
+
+    # def _warmer(self):
+    #     """ One step warmer. """
+    #     self.send(self.command_set.warmer())
+
+    # def _cooler(self):
+    #     """ One step cooler. """
+    #     self.send(self.command_set.cooler())


### PR DESCRIPTION
Adding support for single LED dimmer module from MiLight see #27 

I have captured the network packages between the milight v3 app and the gateway. I have used the White support as basis and made a DimmerGroup for supporting the dimmer.

I have tested this with Home-Assistant by modifying the limitlessled component to use the DimmerGroup of this library. This Worked great, i have not tested night light because that was not supported by home-assistant.