### PR TITLE
Fix low-brightness white for rgbw

### DIFF
--- a/limitlessled/group/rgbw.py
+++ b/limitlessled/group/rgbw.py
@@ -5,7 +5,7 @@ import time
 
 from limitlessled import Color, util
 from limitlessled.group import Group, rate
-from limitlessled.util import steps, hue_of_color
+from limitlessled.util import steps, hue_of_color, saturation_of_color
 
 
 RGBW = 'rgbw'
@@ -44,7 +44,7 @@ class RgbwGroup(Group):
 
         :param color: RGB color tuple.
         """
-        if color == RGB_WHITE:
+        if saturation_of_color(color) == 0:
             self.white()
             return
         self._color = color


### PR DESCRIPTION
This is similar to #34 but actually worse because the wrong hue is not overridden by setting a `saturation` afterwards.

I found this while investigating home-assistant/home-assistant#11121.