### PR TITLE
Consumer thread optimizations

### DIFF
--- a/limitlessled/bridge.py
+++ b/limitlessled/bridge.py
@@ -26,6 +26,7 @@ BRIDGE_INITIALIZATION_COMMAND = [0x20, 0x00, 0x00, 0x00, 0x16, 0x02, 0x62,
                                  0xaf, 0xfe, 0xf7, 0x00, 0x00, 0x1e]
 KEEP_ALIVE_COMMAND_PREAMBLE = [0xD0, 0x00, 0x00, 0x00, 0x02]
 KEEP_ALIVE_RESPONSE_PREAMBLE = [0xd8, 0x0, 0x0, 0x0, 0x07]
+COMMAND_RESPONSE_PREAMBLE = [0x88, 0x00, 0x00, 0x00, 0x03, 0x00]
 KEEP_ALIVE_TIME = 5
 RECONNECT_TIME = 5
 SOCKET_TIMEOUT = 5
@@ -85,6 +86,7 @@ class Bridge(object):
         self._socket.settimeout(SOCKET_TIMEOUT)
         self._socket.connect((ip, port))
         self._command_queue = queue.Queue()
+        self._ack_queue = queue.Queue()
         self._lock = threading.Lock()
         self.active = 0
         self._selected_number = None
@@ -167,10 +169,11 @@ class Bridge(object):
         self._command_queue.put((command, reps, wait))
         # Wait before accepting another command.
         # This keeps individual groups relatively synchronized.
-        sleep = reps * wait * self.active
-        if command.select and self._selected_number != command.group_number:
-            sleep += SELECT_WAIT
-        time.sleep(sleep)
+        if self.version < 6:
+            sleep = reps * wait * self.active
+            if command.select and self._selected_number != command.group_number:
+                sleep += SELECT_WAIT
+            time.sleep(sleep)
 
     def _consume(self):
         """ Consume commands from the queue.
@@ -208,13 +211,21 @@ class Bridge(object):
                             self.is_ready = False
 
                     # Repeat command as necessary.
-                    for _ in range(reps):
-                        if self.is_ready:
-                            if self._send_raw(command.get_bytes(self)):
-                                time.sleep(wait)
-                            else:
-                                # Stop sending on socket error
-                                self.is_ready = False
+                    command_bytes = command.get_bytes(self)
+                    todo = reps
+                    while todo > 0 and self.is_ready:
+                        if self._send_raw(command_bytes):
+                            try:
+                                while self.sn != self._ack_queue.get(timeout=wait):
+                                    pass
+
+                                # ACK received, stop repeating
+                                todo = 0
+                            except queue.Empty:
+                                todo = todo - 1
+                        else:
+                            # Stop sending on socket error
+                            self.is_ready = False
 
             # Wait if bridge is not ready, we're only reading is_ready, no lock needed
             if not self.is_ready and not self.is_closed:
@@ -231,12 +242,18 @@ class Bridge(object):
         """
         try:
             self._socket.send(bytearray(command))
-            self._sn = (self._sn + 1) % 256
             return True
         except (socket.error, socket.timeout):
             # We can get a socket.error or timeout exception if the bridge is disconnected,
             # but we are still sending data. In that case, return False to indicate that data is not sent.
             return False
+
+    def next_sn(self):
+        """
+        Increases the sequential byte and returns it.
+        """
+        self._sn = (self._sn + 1) % 256
+        return self._sn
 
     def _init_connection(self):
         """
@@ -274,7 +291,8 @@ class Bridge(object):
 
     def _keep_alive(self):
         """
-        Send keep alive messages continuously to bridge.
+        Send keep alive messages continuously to bridge and
+        handle command responses.
         """
         send_next_keep_alive_at = 0
         while not self.is_closed:
@@ -294,8 +312,11 @@ class Bridge(object):
                 response = bytearray(12)
                 self._socket.recv_into(response)
 
-                if response[:5] == bytearray(KEEP_ALIVE_RESPONSE_PREAMBLE):
+                if response.startswith(bytearray(KEEP_ALIVE_RESPONSE_PREAMBLE)):
                     send_next_keep_alive_at = need_response_by
+                elif response.startswith(bytearray(COMMAND_RESPONSE_PREAMBLE)):
+                    sn = response[len(COMMAND_RESPONSE_PREAMBLE)]
+                    self._ack_queue.put(sn)
             elif send_next_keep_alive_at < need_response_by:
                 # Acquire the lock to make sure we don't change self.is_ready
                 # while _consume() is sending commands

--- a/limitlessled/group/commands/v6.py
+++ b/limitlessled/group/commands/v6.py
@@ -41,7 +41,7 @@ class CommandV6(Command):
 
         wb1 = bridge.wb1
         wb2 = bridge.wb2
-        sn = bridge.sn
+        sn = bridge.next_sn()
 
         preamble = [0x80, 0x00, 0x00, 0x00, 0x11, wb1, wb2, 0x00, sn, 0x00]
         cmd = [0x31, self.PASSWORD_BYTE1, self.PASSWORD_BYTE2,


### PR DESCRIPTION
This is quite a rework of the consumer thread. It no longer busy polls its queue for new commands, saving some CPU time and in theory improving average latency by ~50ms.

The keep-alive thread is similarly modified to always be blocked, waiting for responses.

Those changes allow my final goal: recognizing v6 ACK responses in the keep-alive thread and making them stop the repeated sending in the consumer thread.

For me, this cuts the duration of sending a message from 0.30s (3x 0.10) down to about 0.03s on average. The difference is very obvious when monkey pushing the Home Assistant color wheel.

Each step is in a separate commit. Only tested with a v6 bridge.